### PR TITLE
Fix 'Api' casing in SLN

### DIFF
--- a/blazor-basic-swa.sln
+++ b/blazor-basic-swa.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.30308.16
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Api", "API\Api.csproj", "{B3A5AFFA-5517-41E6-BAE2-C30558032DD9}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Api", "Api\Api.csproj", "{B3A5AFFA-5517-41E6-BAE2-C30558032DD9}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Client", "Client\Client.csproj", "{52AF5162-0ED3-42DC-A246-39C57DBAA3C7}"
 EndProject


### PR DESCRIPTION
To make it work in case-sensitive file systems, such as those typically used in Linux.