### PR TITLE
Update Api.csproj

### DIFF
--- a/Api/Api.csproj
+++ b/Api/Api.csproj
@@ -5,6 +5,7 @@
     <RootNamespace>BlazorApp.Api</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.0.1" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Fixes issue with  <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.0.1" /> pulling in System.Runtime.CompilerServices.Unsafe" Version="4.5.0" via dependencies which is incompatible with net6.0, adding System.Runtime.CompilerServices.Unsafe" Version="6.0.0" will that one over the "4.5.0"

fixes issue #25 