### PR TITLE
Update task.json to point towards actual targeted version (dotnet 7)

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -71,7 +71,7 @@
 			"type": "func",
 			"dependsOn": "build",
 			"options": {
-				"cwd": "${workspaceFolder}/Api/bin/Debug/net6.0"
+				"cwd": "${workspaceFolder}/Api/bin/Debug/net7.0"
 			},
 			"command": "host start",
 			"isBackground": true,


### PR DESCRIPTION
The template is setting dotnet 7 as default version of the project, so this will fail if user has dotnet 7 but doesn't have dotnet 6