### PR TITLE
Update dotnet version from 6 -> 7 in tasks.json config for vscode

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -71,7 +71,7 @@
 			"type": "func",
 			"dependsOn": "build",
 			"options": {
-				"cwd": "${workspaceFolder}/Api/bin/Debug/net6.0"
+				"cwd": "${workspaceFolder}/Api/bin/Debug/net7.0"
 			},
 			"command": "host start",
 			"isBackground": true,


### PR DESCRIPTION
Update dotnet version from 6 -> 7 in tasks.json config for vscode.
If a user doesn't have dontet 6 this will fail for them.
The main project is configured to run using dotnet7 so I don't see the point of looking for dotnet 6 here.