### PR TITLE
Configure Cross-Origin Resource Sharing (CORS) locally

### DIFF
--- a/Api/Properties/launchSettings.json
+++ b/Api/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+      "Api": {
+          "commandName": "Project",
+          "commandLineArgs": "start --cors *"
+      }
+  }
+}


### PR DESCRIPTION
You won't have to worry about Cross-Origin Resource Sharing (CORS) when you publish to Azure Static Web Apps. Azure Static Web Apps automatically configure your app to communicate with your API on Azure using a reverse proxy. But when running locally, you need to configure CORS to allow your web app and API to communicate.

Now, prompt Azure Functions to allow your web app to request HTTP to the API on your computer.