### PR TITLE
Correctly await WriteAsJsonAsync in HttpTrigger.Run method

### DIFF
--- a/Api/WeatherForecastFunction.cs
+++ b/Api/WeatherForecastFunction.cs
@@ -16,7 +16,7 @@ namespace Api
         }
 
         [Function("WeatherForecast")]
-        public HttpResponseData Run([HttpTrigger(AuthorizationLevel.Anonymous, "get")] HttpRequestData req)
+        public async Task<HttpResponseData> Run([HttpTrigger(AuthorizationLevel.Anonymous, "get")] HttpRequestData req)
         {
             var randomNumber = new Random();
             var temp = 0;
@@ -29,7 +29,7 @@ namespace Api
             }).ToArray();
 
             var response = req.CreateResponse(HttpStatusCode.OK);
-            response.WriteAsJsonAsync(result);
+            await response.WriteAsJsonAsync(result);
 
             return response;
         }


### PR DESCRIPTION
Thanks for your blazor-starter project that indeed got me started with my Azure static web app!

Visual Studio warned me rightly about the unawaited `WriteAsJsonAsync` in the `HttpTrigger.Run` method. 
It's a small fix but might be helpful - especially for beginners.